### PR TITLE
issue #4: migrate standard resources into ETL

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,5 @@
 const { standardMetadata } = require("./references/dd-1.7/standard-metadata");
-const {
-  standardResources,
-} = require("../../commonConstants/standardResources");
+const { standardResources } = require("./constants/standard-resources");
 
 const getFieldDetails = async (fieldName, resourceName) => {
   return standardMetadata.fields.find(

--- a/lib/constants/standard-resources.js
+++ b/lib/constants/standard-resources.js
@@ -1,0 +1,32 @@
+const standardResources = [
+  "Property",
+  "Member",
+  "Office",
+  "Contacts",
+  "Media",
+  "HistoryTransactional",
+  "ContactListings",
+  "InternetTracking",
+  "SavedSearch",
+  "OpenHouse",
+  "Prospecting",
+  "Queue",
+  "Rules",
+  "Teams",
+  "Showing",
+  "TeamMembers",
+  "OUID",
+  "ContactListingNotes",
+  "OtherPhone",
+  "PropertyGreenVerification",
+  "PropertyPowerProduction",
+  "PropertyRooms",
+  "PropertyUnitTypes",
+  "SocialMedia",
+  "Field",
+  "Lookup",
+];
+
+module.exports = {
+  standardResources,
+};


### PR DESCRIPTION
This part of code inside `common.js`

```js
const {
  standardResources,
} = require("../../commonConstants/standardResources");
```
was referencing a file from the cert codebase which was causing a build error. I added the standard resources it needed locally. Now we already have a service for getting standard resources but using it inside this package would require all our functions to be async. So for now I have just moved the hardcoded data that it was previously using.